### PR TITLE
10.10.38.xcpng.3

### DIFF
--- a/SOURCES/host-installer-10.10.38.xcpng.2.tar.gz
+++ b/SOURCES/host-installer-10.10.38.xcpng.2.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:bf4436c45b4d5b5adfb515faf802812f76816b031e09cbfbed75e349f3054e35
-size 171570

--- a/SOURCES/host-installer-10.10.38.xcpng.3.tar.gz
+++ b/SOURCES/host-installer-10.10.38.xcpng.3.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:030e903cb832d750b77d4715558ed861e8d60f4a08a81ce484cf93c243b4c2f9
+size 171589

--- a/SPECS/host-installer.spec
+++ b/SPECS/host-installer.spec
@@ -3,7 +3,7 @@
 
 Summary: XenServer Installer
 Name: host-installer
-Version: 10.10.38.xcpng.2
+Version: 10.10.38.xcpng.3
 Release: 1%{?dist}
 License: GPLv2
 Group: Applications/System
@@ -216,6 +216,11 @@ done
 rm -f /tmp/firmware-used.$$
 
 %changelog
+* Thu Jul 23 2026 Yann Dirson <yann.dirson@vates.tech> - 10.10.38.xcpng.3-1
+- Update to v10.10.38.xcpng.3 release:
+  - Fix identification of the LINSTOR versions in the repo, when the required one
+    is not the most recent one
+
 * Thu Jul 09 2026 Yann Dirson <yann.dirson@vates.tech> - 10.10.38.xcpng.2-1
 - Update to v10.10.38.xcpng.2 release:
   - Fix RAID regressions:


### PR DESCRIPTION
This fixes XOSTOR upgrades from 8.2, now that 8.3 has a newer LINSTOR version than 8.2.
