### PR TITLE
Update to v10.10.38.xcpng.4 release

### DIFF
--- a/SOURCES/host-installer-10.10.38.xcpng.3.tar.gz
+++ b/SOURCES/host-installer-10.10.38.xcpng.3.tar.gz
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:030e903cb832d750b77d4715558ed861e8d60f4a08a81ce484cf93c243b4c2f9
-size 171589

--- a/SOURCES/host-installer-10.10.38.xcpng.4.tar.gz
+++ b/SOURCES/host-installer-10.10.38.xcpng.4.tar.gz
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:2bf3d5c1158cadfd780f598868ef071fc6e15ce64d7cd46a1dd83e6f662e8b60
+size 171828

--- a/SPECS/host-installer.spec
+++ b/SPECS/host-installer.spec
@@ -3,7 +3,7 @@
 
 Summary: XenServer Installer
 Name: host-installer
-Version: 10.10.38.xcpng.3
+Version: 10.10.38.xcpng.4
 Release: 1%{?dist}
 License: GPLv2
 Group: Applications/System
@@ -216,6 +216,11 @@ done
 rm -f /tmp/firmware-used.$$
 
 %changelog
+* Wed Aug 05 2026 Yann Dirson <yann.dirson@vates.tech> - 10.10.38.xcpng.4-1
+- Update to v10.10.38.xcpng.4 release:
+  - Fix linstor ugrade to pull specific version of xcp-ng-linstor
+  - Fail when a package for install is not found
+
 * Thu Jul 23 2026 Yann Dirson <yann.dirson@vates.tech> - 10.10.38.xcpng.3-1
 - Update to v10.10.38.xcpng.3 release:
   - Fix identification of the LINSTOR versions in the repo, when the required one


### PR DESCRIPTION
One more fix for XOSTOR upgrades from 8.2, now that 8.3 has a newer LINSTOR version than 8.2.
